### PR TITLE
chore(Footer): update website GH URL

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -48,7 +48,7 @@ const today = new Date();
       <p class="flex items-center gap-2 sm:flex-row-reverse">
         <span>braun bauen {today.getFullYear()}</span>
         <a
-          href="https://github.com/isaacbraun/braun-bauen-site"
+          href="https://github.com/braun-bauen/site"
           target="_blank"
           title="View this website's GitHub repository"
         >


### PR DESCRIPTION
Updates the website GitHub URL in the footer since it was moved into the
Braun Bauen organization.
